### PR TITLE
Real images

### DIFF
--- a/server.py
+++ b/server.py
@@ -90,20 +90,23 @@ def check_projects_path():
 
 class ServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
-    def do_OPTIONS(self):
-        logging.info(self.headers)
-
-        self.send_response(200, "ok")
+    def cors(self):
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods',
                          'GET, POST, OPTIONS')
         self.send_header('Access-Control-Allow-Headers',
                          'x-project-id, x-api-key')
 
+    def do_OPTIONS(self):
+        logging.info(self.headers)
+        self.send_response(200, 'ok')
+        self.cors()
+
     @authorize
     @check
     def do_GET(self):
         self.send_response(200)
+        self.cors()
         self.send_header("Content-type", "application/json")
         self.end_headers()
 
@@ -117,6 +120,7 @@ class ServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     @check
     def do_POST(self):
         self.send_response(200)
+        self.cors()
         self.end_headers()
 
         content_len = int(self.headers.getheader('content-length', 0))

--- a/server.py
+++ b/server.py
@@ -131,6 +131,7 @@ if __name__ == '__main__':
     httpd = SocketServer.TCPServer((Settings.ADDRESS,
                                     Settings.PORT),
                                    ServerHandler)
+    print 'Starting server on {}:{}'.format(Settings.ADDRESS, Settings.PORT)
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
Replaces #3 

Requires https://github.com/walterbender/turtleblocksjs/pull/194

```
commit 7605abb9a651fef97a5a99ba39f7c88cca54a444
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Fri Mar 13 21:15:44 2015 +1100

    Serve real images, not b64 images

    This makes client much more simple.  It goes from:

        1. Download list
        2. (Buggy) Recursivly download images (must be async)
        3. Add images to HTML

    With this server change it can be:

        1. Download list
        2. Add images to HTML
        (The browser does the downloading!)

commit 8a48f85d494700cabc6aa891c935b1292e7d3b42
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Fri Mar 13 21:10:57 2015 +1100

    Serve CORS headers for all requests

    Firefox (maybe Chrome too) needs CORS headers on every request (not only
    OPTIONS) to feel ok about sending data cross origin.  Currently this is done
    by apache2 on sunjammer, but it is a hack.

commit 71a5c7a02f0ee8ee1950c326302756568a3d03cb
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Fri Mar 13 21:08:44 2015 +1100

    Show a serving on X:Y message on startup
```
